### PR TITLE
Arash

### DIFF
--- a/src/components/CheckboxList.js
+++ b/src/components/CheckboxList.js
@@ -18,7 +18,7 @@ export default function CheckboxList({ updateParent, selected = [], options }) {
       result = [...selectedList, value];
     }
     setSelectedList(result);
-    updateParent(name, selectedList);
+    updateParent(name, result);
   }
 
   return (

--- a/src/components/MembersCheckbox.js
+++ b/src/components/MembersCheckbox.js
@@ -1,9 +1,11 @@
-import React from "react";
-
+import React, { useState } from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
+import FloatingLabel from "react-bootstrap/FloatingLabel";
+import { filterByKeys } from "../const";
 
 export default function MembersCheckbox({ update, selected, allMembers }) {
+  const [search, setSearch] = useState("");
   function handleChange(member) {
     let result;
 
@@ -18,24 +20,41 @@ export default function MembersCheckbox({ update, selected, allMembers }) {
     <Dropdown autoClose="outside" style={{ display: "inline-block" }}>
       <Dropdown.Toggle>Membros</Dropdown.Toggle>
       <Dropdown.Menu>
-        {allMembers.map((member) => (
-          <Dropdown.Item key={member._id} onClick={() => handleChange(member)}>
-            <Form.Check
-              name="members"
-              inline
-              type="checkbox"
-              value={member._id}
-              onChange={() => {}}
-              {...(() => {
-                let exists = ~selected.indexOf(member);
-                return { key: member._id + exists, checked: exists };
-              })()}
-            />
-            <Form.Label>
-              {member.nome} - {member.matricula}
-            </Form.Label>
-          </Dropdown.Item>
-        ))}
+        <FloatingLabel
+          controlId="floatingInput"
+          label="Pesquise por nome / habilidades"
+          className="my-3">
+          <Form.Control
+            type="text"
+            placeholder="pesquise"
+            value={search}
+            onChange={({ target }) => setSearch(target.value)}
+          />
+        </FloatingLabel>
+        {allMembers
+          .filter((member) =>
+            filterByKeys(member, ["nome", "habilidades"], search)
+          )
+          .map((member) => (
+            <Dropdown.Item
+              key={member._id}
+              onClick={() => handleChange(member)}>
+              <Form.Check
+                name="members"
+                inline
+                type="checkbox"
+                value={member._id}
+                onChange={() => {}}
+                {...(() => {
+                  let exists = ~selected.indexOf(member);
+                  return { key: member._id + exists, checked: exists };
+                })()}
+              />
+              <Form.Label>
+                {member.nome} - {member.matricula}
+              </Form.Label>
+            </Dropdown.Item>
+          ))}
       </Dropdown.Menu>
     </Dropdown>
   );

--- a/src/components/ModalTarefas.js
+++ b/src/components/ModalTarefas.js
@@ -44,8 +44,8 @@ function ModalTarefas({
     e.preventDefault();
     e.stopPropagation();
     setShowRepeticao(false);
-    if (isEditing) handlePut();
-    else handlePost();
+    if (isEditing) handlePost();
+    else handlePut();
   }
 
   async function handlePost() {
@@ -204,18 +204,6 @@ function ModalTarefas({
                   />
                 </Form.Group>
               </Col>
-              <Col>
-                <Form.Group className="mb-3">
-                  <Form.Label htmlFor="inicio">Início</Form.Label>
-                  <Form.Control
-                    type="date"
-                    id="inicio"
-                    name="inicio"
-                    value={form.inicio}
-                    onChange={handleChange}
-                  />
-                </Form.Group>
-              </Col>
             </Row>
             <Row>
               <Col>
@@ -254,7 +242,7 @@ function ModalTarefas({
           </Form>
         </Modal.Body>
         <Modal.Footer>
-          {isEditing() ? (
+          {!isEditing() ? (
             <>
               <Button variant="outline-danger" onClick={handleDelete}>
                 Excluir tarefa

--- a/src/components/ModalTarefas.js
+++ b/src/components/ModalTarefas.js
@@ -19,14 +19,77 @@ function ModalTarefas({
   const [members, setMembers] = useState(currentMembers);
   const [form, setForm] = useState({ ...taskObject, ...formObj });
   const [validated] = useState(false);
+  const [showRepeticao, setShowRepeticao] = useState(false);
 
   function handleClose() {
     setShow(false);
   }
 
+  function callRepeticao() {
+    handleClose();
+    setShowRepeticao(true);
+  }
+
+  function handleRepeticao() {
+    setShowRepeticao(false);
+  }
+
+  function isEditing(formObj) {
+    if (!formObj) return false;
+    return !!Object.keys(formObj).length;
+  }
+
+  /* CRUD */
   function handleSubmit(e) {
     e.preventDefault();
     e.stopPropagation();
+    setShowRepeticao(false);
+    if (isEditing) handlePut();
+    else handlePost();
+  }
+
+  async function handlePost() {
+    let clone = { ...form };
+    try {
+      await axios.post("https://ironrest.cyclic.app/gtr_task/", clone);
+      toast.success("Tarega criada com sucesso! :D");
+      setReload(!reload);
+    } catch (error) {
+      setShow(true);
+      console.log(error);
+      toast.error("Algo deu errado. Tente novamente.");
+    }
+  }
+
+  async function handlePut() {
+    try {
+      const clone = { ...form };
+      delete clone._id;
+
+      await axios.put(
+        `https://ironrest.cyclic.app/gtr_task/${form._id}`,
+        clone
+      );
+
+      toast.success("Alterações salvas");
+      setReload(!reload);
+    } catch (error) {
+      setShow(true);
+      console.log(error);
+      toast.error("Algo deu errado. Tente novamente.");
+    }
+  }
+
+  async function handleDelete(e) {
+    try {
+      await axios.delete(`https://ironrest.cyclic.app/gtr_task/${form._id}`);
+      toast.success("Tarefa deletada com sucesso");
+      setReload(!reload);
+      setShow(false);
+    } catch (error) {
+      console.log(error);
+      toast.error("Algo deu errado ao deletar essa tarefa.");
+    }
   }
 
   function handleChange({ target }) {
@@ -49,50 +112,6 @@ function ModalTarefas({
         value: selected.map((item) => "" + item.matricula),
       },
     });
-  }
-
-  async function handlePost() {
-    let clone = { ...form };
-    try {
-      await axios.post("https://ironrest.cyclic.app/gtr_task/", clone);
-      toast.success("Tarega criada com sucesso! :D");
-      setReload(!reload);
-      handleClose(); // fechar o modal
-    } catch (error) {
-      console.log(error);
-      toast.error("Algo deu errado. Tente novamente.");
-    }
-  }
-
-  async function handlePut() {
-    try {
-      const clone = { ...form };
-      delete clone._id;
-
-      await axios.put(
-        `https://ironrest.cyclic.app/gtr_task/${form._id}`,
-        clone
-      );
-
-      toast.success("Alterações salvas");
-      setReload(!reload);
-      setShow(false);
-    } catch (error) {
-      console.log(error);
-      toast.error("Algo deu errado. Tente novamente.");
-    }
-  }
-
-  async function handleDelete(e) {
-    try {
-      await axios.delete(`https://ironrest.cyclic.app/gtr_task/${form._id}`);
-      toast.success("Tarefa deletada com sucesso");
-      setReload(!reload);
-      setShow(false);
-    } catch (error) {
-      console.log(error);
-      toast.error("Algo deu errado ao deletar essa tarefa.");
-    }
   }
 
   return (
@@ -118,68 +137,6 @@ function ModalTarefas({
                     <option value="Médio">Médio</option>
                     <option value="Alto">Alto</option>
                   </Form.Select>
-                </Form.Group>
-              </Col>
-              <Col>
-                <Form.Group className="mb-3">
-                  <Form.Label>Periodicidade</Form.Label>
-                  <Row>
-                    <Col>
-                      <CheckboxList
-                        updateParent={handleCheckbox}
-                        selected={form.periodicidade}
-                        options={{
-                          name: "periodicidade",
-                          type: "radio",
-                          list: periodicity,
-                        }}
-                      />
-                    </Col>
-                  </Row>
-                  <Row>
-                    {form.periodicidade === "semanal" && (
-                      <Col>
-                        <CheckboxList
-                          updateParent={handleCheckbox}
-                          selected={form.detalhesPeriodicidade}
-                          options={{
-                            name: "detalhesPeriodicidade",
-                            type: "checkbox",
-                            list: week,
-                          }}
-                        />
-                      </Col>
-                    )}
-                    {form.periodicidade === "mensal" && (
-                      <Col>
-                        <Form.Group as={Row} className="mb-3">
-                          <Form.Label
-                            column
-                            sm="2"
-                            htmlFor="detalhesPeriodicidade">
-                            Dia
-                          </Form.Label>
-                          <Col sm="10">
-                            <Form.Control
-                              type="number"
-                              id="detalhesPeriodicidade"
-                              name="detalhesPeriodicidade"
-                              placeholder="Dia do mês"
-                              value={
-                                typeof form.detalhesPeriodicidade === "string"
-                                  ? form.detalhesPeriodicidade
-                                  : "1"
-                              }
-                              min="1"
-                              max="31"
-                              onChange={handleChange}
-                              autoFocus
-                            />
-                          </Col>
-                        </Form.Group>
-                      </Col>
-                    )}
-                  </Row>
                 </Form.Group>
               </Col>
             </Row>
@@ -267,13 +224,14 @@ function ModalTarefas({
                     Minutos Estimados
                   </Form.Label>
                   <Form.Control
-                    type="number"
+                    type="time"
                     id="tempoestimado"
                     name="tempoestimado"
                     value={form.tempoestimado}
                     onChange={handleChange}
-                    min="5"
-                    placeholder="Tempo em minutos para concluir a tarefa"></Form.Control>
+                    min="00:00"
+                    max="08:00"
+                    placeholder="Tempo estimado para concluir a tarefa"></Form.Control>
                 </Form.Group>
               </Col>
               <Col>
@@ -285,6 +243,7 @@ function ModalTarefas({
                     name="prazoFinal"
                     value={form.prazoFinal}
                     onChange={handleChange}
+                    required
                   />
                   <Form.Control.Feedback type="invalid">
                     A data do prazo final não pode uma pretérita.
@@ -295,25 +254,96 @@ function ModalTarefas({
           </Form>
         </Modal.Body>
         <Modal.Footer>
-          {!Object.keys(formObj).length ? (
-            <>
-              <Button variant="secondary" onClick={handleClose}>
-                Cancelar
-              </Button>
-              <Button variant="primary" onClick={handlePost}>
-                Adicionar tarefa
-              </Button>
-            </>
-          ) : (
+          {isEditing() ? (
             <>
               <Button variant="outline-danger" onClick={handleDelete}>
                 Excluir tarefa
               </Button>
-              <Button variant="primary" onClick={handlePut}>
+              <Button variant="primary" onClick={callRepeticao}>
                 Salvar
               </Button>
             </>
+          ) : (
+            <>
+              <Button variant="secondary" onClick={handleClose}>
+                Cancelar
+              </Button>
+              <Button variant="primary" onClick={callRepeticao}>
+                Adicionar tarefa
+              </Button>
+            </>
           )}
+        </Modal.Footer>
+      </Modal>
+
+      {/* MODAL REPETIÇÕES */}
+      <Modal show={showRepeticao} onHide={handleRepeticao} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Formulário de criação de tarefas</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Group className="mb-3">
+            <Form.Label>Periodicidade</Form.Label>
+            <Row>
+              <Col>
+                <CheckboxList
+                  updateParent={handleCheckbox}
+                  selected={form.periodicidade}
+                  options={{
+                    name: "periodicidade",
+                    type: "radio",
+                    list: periodicity,
+                  }}
+                />
+              </Col>
+            </Row>
+            <Row>
+              {form.periodicidade === "semanal" && (
+                <Col>
+                  <CheckboxList
+                    updateParent={handleCheckbox}
+                    selected={form.detalhesPeriodicidade}
+                    options={{
+                      name: "detalhesPeriodicidade",
+                      type: "checkbox",
+                      list: week,
+                    }}
+                  />
+                </Col>
+              )}
+              {form.periodicidade === "mensal" && (
+                <Col>
+                  <Form.Group as={Row} className="mb-3">
+                    <Form.Label column sm="2" htmlFor="detalhesPeriodicidade">
+                      Dia
+                    </Form.Label>
+                    <Col sm="10">
+                      <Form.Control
+                        type="number"
+                        id="detalhesPeriodicidade"
+                        name="detalhesPeriodicidade"
+                        placeholder="Dia do mês"
+                        value={
+                          typeof form.detalhesPeriodicidade === "string"
+                            ? form.detalhesPeriodicidade
+                            : "1"
+                        }
+                        min="1"
+                        max="31"
+                        onChange={handleChange}
+                        autoFocus
+                      />
+                    </Col>
+                  </Form.Group>
+                </Col>
+              )}
+            </Row>
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="primary" onClick={handleSubmit}>
+            Concluir
+          </Button>
         </Modal.Footer>
       </Modal>
     </div>

--- a/src/const.js
+++ b/src/const.js
@@ -32,12 +32,36 @@ export let taskObject = {
   membros: [],
   Referencia: "",
   inicio: today_formated,
-  tempoestimado: 5,
+  tempoestimado: "00:30",
   prazoFinal: today_formated,
   status: "Ativo",
 };
 
 // https://stackoverflow.com/a/37511463
-export function removeAccents(string) {
+function removeAccents(string) {
   return string.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+}
+
+export function filterByKeys(obj, keys, search) {
+  if (!search.length || !obj) return true;
+  search = removeAccents(search).toLowerCase();
+
+  for (let key of keys) {
+    let values = obj[key];
+
+    // eslint-disable-next-line eqeqeq
+    if (values == undefined) return false;
+    if (typeof values === "string") values = [values];
+    if (!Array.isArray(values))
+      throw Error(
+        "Não é possível filtar, pois um dos valores recebidos é de tipo diverso de array e string"
+      );
+
+    for (let str of values) {
+      console.log(str, search);
+      if (removeAccents(str.toLowerCase()).includes(search)) return true;
+    }
+  }
+
+  return false;
 }

--- a/src/const.js
+++ b/src/const.js
@@ -36,3 +36,8 @@ export let taskObject = {
   prazoFinal: today_formated,
   status: "Ativo",
 };
+
+// https://stackoverflow.com/a/37511463
+export function removeAccents(string) {
+  return string.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+}

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -72,6 +72,7 @@ export default function Tasks() {
               <th>Minutos Estimados</th>
               <th>Prazo Final</th>
               <th>Tags</th>
+              <th>Editar</th>
               <th>Detalhes</th>
             </tr>
           </thead>
@@ -100,6 +101,11 @@ export default function Tasks() {
                     variant="outline-secondary"
                     size="sm"
                     onClick={() => handleEditTask(task)}>
+                    Editar
+                  </Button>
+                </td>
+                <td>
+                  <Button variant="outline-secondary" size="sm">
                     Detalhes
                   </Button>
                 </td>

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -13,6 +13,12 @@ import { toast } from "react-hot-toast";
 import ModalTarefas from "../components/ModalTarefas";
 import { filterByKeys } from "../const";
 
+const priorities = {
+  Alto: 2,
+  Médio: 1,
+  Baixo: 0,
+};
+
 export default function Tasks() {
   const [tasks, setTasks] = useState([]);
   const [tasksSearch, setTaskSearch] = useState("");
@@ -102,10 +108,14 @@ export default function Tasks() {
             {tasks
               .filter((task) => filterByKeys(task, ["status"], tasksSearch))
               .sort((task1, task2) => {
-                let first = task1.prazoFinal.localeCompare(task2.prazoFinal);
-                if (first === 0)
-                  return task1.inicio.localeCompare(task2.inicio);
-                return first;
+                let first =
+                  priorities[task2.prioridade] - priorities[task1.prioridade];
+                if (first !== 0) return first;
+
+                let second = task1.prazoFinal.localeCompare(task2.prazoFinal);
+                if (second !== 0) return second;
+
+                return task1.inicio.localeCompare(task2.inicio);
               })
               .map((task) => (
                 <tr key={task._id}>

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -1,11 +1,21 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
-import { Table, Container, Button, Col, Row } from "react-bootstrap";
+import {
+  Table,
+  Container,
+  Button,
+  Col,
+  Row,
+  FloatingLabel,
+  Form,
+} from "react-bootstrap";
 import { toast } from "react-hot-toast";
 import ModalTarefas from "../components/ModalTarefas";
+import { removeAccents } from "../const";
 
 export default function Tasks() {
   const [tasks, setTasks] = useState([]);
+  const [tasksSearch, setTaskSearch] = useState("");
   const [allMembers, setAllMembers] = useState([]);
   const [members, setMembers] = useState([]);
   const [showModal, setShowModal] = useState(false);
@@ -53,12 +63,24 @@ export default function Tasks() {
       <Container>
         <Row>
           <Col>
-            <h3>Tarefas atribuídas</h3>
+            <h3>Tarefas abertas</h3>
           </Col>
           <Col md="auto">
             <Button onClick={handleModal}>Adicionar</Button>
           </Col>
         </Row>
+        <FloatingLabel
+          controlId="floatingInput"
+          label="Pesquise por status"
+          className="my-3">
+          <Form.Control
+            type="text"
+            placeholder="pesquise"
+            value={tasksSearch}
+            onChange={({ target }) => setTaskSearch(target.value)}
+          />
+        </FloatingLabel>
+
         <Table striped bordered hover>
           <thead>
             <tr>
@@ -72,45 +94,62 @@ export default function Tasks() {
               <th>Minutos Estimados</th>
               <th>Prazo Final</th>
               <th>Tags</th>
-              <th>Editar</th>
               <th>Detalhes</th>
+              <th>Editar</th>
             </tr>
           </thead>
           <tbody>
-            {tasks.map((task) => (
-              <tr key={task._id}>
-                <td>{task.status}</td>
-                <td>{task.nome}</td>
-                <td>{task.prioridade}</td>
-                <td>{task.periodicidade}</td>
-                <td>{task.Referencia}</td>
-                <td>
-                  {allMembers
-                    .filter((item) => task.membros.includes(item.matricula))
-                    .map((member) => member.nome)
-                    .join(", ")}
-                </td>
-                <td>{new Date(task.inicio + " 00:00").toLocaleDateString()}</td>
-                <td>{task.tempoestimado}</td>
-                <td>
-                  {new Date(task.prazoFinal + " 00:00").toLocaleDateString()}
-                </td>
-                <td>{task.tags.join(", ")}</td>
-                <td>
-                  <Button
-                    variant="outline-secondary"
-                    size="sm"
-                    onClick={() => handleEditTask(task)}>
-                    Editar
-                  </Button>
-                </td>
-                <td>
-                  <Button variant="outline-secondary" size="sm">
-                    Detalhes
-                  </Button>
-                </td>
-              </tr>
-            ))}
+            {tasks
+              .filter((task) => {
+                if (!tasksSearch.length) return true;
+                return ["status"].find((key) =>
+                  removeAccents(task[key].toLowerCase()).includes(
+                    removeAccents(tasksSearch.toLowerCase())
+                  )
+                );
+              })
+              .sort((task1, task2) => {
+                let first = task1.prazoFinal.localeCompare(task2.prazoFinal);
+                if (first === 0)
+                  return task1.inicio.localeCompare(task2.inicio);
+                return first;
+              })
+              .map((task) => (
+                <tr key={task._id}>
+                  <td>{task.status}</td>
+                  <td>{task.nome}</td>
+                  <td>{task.prioridade}</td>
+                  <td>{task.periodicidade}</td>
+                  <td>{task.Referencia}</td>
+                  <td>
+                    {allMembers
+                      .filter((item) => task.membros.includes(item.matricula))
+                      .map((member) => member.nome)
+                      .join(", ")}
+                  </td>
+                  <td>
+                    {new Date(task.inicio + " 00:00").toLocaleDateString()}
+                  </td>
+                  <td>{task.tempoestimado}</td>
+                  <td>
+                    {new Date(task.prazoFinal + " 00:00").toLocaleDateString()}
+                  </td>
+                  <td>{task.tags.join(", ")}</td>
+                  <td>
+                    <Button variant="outline-secondary" size="sm">
+                      Detalhes
+                    </Button>
+                  </td>
+                  <td>
+                    <Button
+                      variant="outline-secondary"
+                      size="sm"
+                      onClick={() => handleEditTask(task)}>
+                      Editar
+                    </Button>
+                  </td>
+                </tr>
+              ))}
           </tbody>
         </Table>
 

--- a/src/pages/Tasks.js
+++ b/src/pages/Tasks.js
@@ -11,7 +11,7 @@ import {
 } from "react-bootstrap";
 import { toast } from "react-hot-toast";
 import ModalTarefas from "../components/ModalTarefas";
-import { removeAccents } from "../const";
+import { filterByKeys } from "../const";
 
 export default function Tasks() {
   const [tasks, setTasks] = useState([]);
@@ -100,14 +100,7 @@ export default function Tasks() {
           </thead>
           <tbody>
             {tasks
-              .filter((task) => {
-                if (!tasksSearch.length) return true;
-                return ["status"].find((key) =>
-                  removeAccents(task[key].toLowerCase()).includes(
-                    removeAccents(tasksSearch.toLowerCase())
-                  )
-                );
-              })
+              .filter((task) => filterByKeys(task, ["status"], tasksSearch))
               .sort((task1, task2) => {
                 let first = task1.prazoFinal.localeCompare(task2.prazoFinal);
                 if (first === 0)


### PR DESCRIPTION
Página de administração de tarefas:
  - adicionar input para filtrar as tarefas pelo nome ou status
  - mudar o título para Tarefas abertas
  - trocar o lugar dos botões editar e detalhes
  - corrigir bug: quando se está editando a repetição semanal não está sendo possível remover um dia da semana já marcado
  
  -> Componente de criação de tarefas (modal)
     • alterar o campo "tempo estimado" para coletar e apresentar a informação em horas e minutos
     • remover o campo início e enviar a informação automaticamente ao submitar
     • marcar como obrigatórios os campos "nome" e "prazo final"
     • fazer a validação dos campos
     • retirar o campo "periodicidade" e dar opção após salvar ou editar
     • refatorar o componente membros, fazendo adicionar um input para filtrar por nome ou habilidades